### PR TITLE
Note save bookmark and memo in streaming

### DIFF
--- a/backend/src/main/java/bento/backend/constant/ErrorMessages.java
+++ b/backend/src/main/java/bento/backend/constant/ErrorMessages.java
@@ -19,5 +19,6 @@ public class ErrorMessages {
     public static final String MEMO_TIMESTAMP_ERROR = "The memo timestamp is invalid. Please provide a valid timestamp.";
     public static final String MEMO_ALREADY_EXISTS_ERROR = "A memo with the same timestamp already exists for this note.";
     public static final String MEMO_ID_NOT_FOUND_ERROR = "The memo with the specified ID could not be found : ";
+    public static final String INVALID_JSON_FORMAT = "The provided JSON data is invalid. Please check bookmarks and memos and try again.";
     // 필요한 다른 에러 메시지들을 추가
 }

--- a/backend/src/main/java/bento/backend/controller/NoteController.java
+++ b/backend/src/main/java/bento/backend/controller/NoteController.java
@@ -1,14 +1,10 @@
 package bento.backend.controller;
 
-import bento.backend.dto.request.BookmarkCreateRequest;
-import bento.backend.dto.request.MemoCreateRequest;
 import bento.backend.service.auth.AuthService;
 import bento.backend.service.note.NoteService;
 import bento.backend.service.file.FileService;
-import bento.backend.domain.Note;
 import bento.backend.domain.User;
 import bento.backend.domain.Folder;
-import bento.backend.repository.NoteRepository;
 import bento.backend.dto.response.NoteListResponse;
 import bento.backend.dto.response.NoteDetailResponse;
 import bento.backend.dto.response.MessageResponse;
@@ -17,19 +13,11 @@ import bento.backend.dto.response.NoteSummaryResponse;
 import bento.backend.dto.request.NoteCreateRequest;
 import bento.backend.dto.request.NoteUpdateRequest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
+import java.util.List;
 
 
 @RestController
@@ -51,34 +39,8 @@ public class NoteController {
 	@PostMapping("")
 	public ResponseEntity<MessageResponse> createNote(
 			@RequestHeader("Authorization") String token,
-			@RequestPart(value = "file", required = true) MultipartFile file,
-			@RequestPart(value = "note") NoteCreateRequest request,
-			@RequestPart(value = "bookmarks", required = false) String bookmarksJson,
-			@RequestPart(value = "memos", required = false) String memosJson
+			@ModelAttribute NoteCreateRequest request
 	) {
-		ObjectMapper objectMapper = new ObjectMapper();
-
-		try {
-			// Parse bookmarks and memos
-			List<BookmarkCreateRequest> bookmarks = objectMapper.readValue(
-					bookmarksJson,
-					new TypeReference<List<BookmarkCreateRequest>>() {}
-			);
-			List<MemoCreateRequest> memos = objectMapper.readValue(
-					memosJson,
-					new TypeReference<List<MemoCreateRequest>>() {}
-			);
-
-			// Set parsed data
-			request.setBookmarks(bookmarks);
-			request.setMemos(memos);
-			request.setFile(file);
-
-		} catch (JsonProcessingException e) {
-			return ResponseEntity.badRequest()
-					.body(new MessageResponse("Invalid JSON format: " + e.getMessage()));
-		}
-
 		User user = authService.getUserFromToken(token.replace("Bearer ", ""));
 
 		String filePath = fileService.uploadFile(request.getFile());

--- a/backend/src/main/java/bento/backend/domain/Bookmark.java
+++ b/backend/src/main/java/bento/backend/domain/Bookmark.java
@@ -21,4 +21,9 @@ public class Bookmark {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "note_id", nullable = false)
     private Note note;
+
+    // 연관관계 메서드
+    public void setNote(Note note) {
+        this.note = note;
+    }
 }

--- a/backend/src/main/java/bento/backend/domain/Memo.java
+++ b/backend/src/main/java/bento/backend/domain/Memo.java
@@ -30,4 +30,9 @@ public class Memo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "note_id", nullable = false)
     private Note note;
+
+    // 연관관계 메서드
+    public void setNote(Note note) {
+        this.note = note;
+    }
 }

--- a/backend/src/main/java/bento/backend/domain/Note.java
+++ b/backend/src/main/java/bento/backend/domain/Note.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -26,8 +27,6 @@ public class Note {
 	@Column(name = "title")
 	private String title;
 
-	// JSON array of script objects. This is a response from the Naver Speech-to-Text API.
-	// This is a temporary solution. We will change this to a list of script objects.
 	@Column(name = "content", columnDefinition = "json")
 	private String content;
 
@@ -51,10 +50,12 @@ public class Note {
 	private User user;
 
 	@OneToMany(mappedBy = "note", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Bookmark> bookmarks;
+	@Builder.Default
+	private List<Bookmark> bookmarks = new ArrayList<>();
 
 	@OneToMany(mappedBy = "note", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Memo> memos;
+	@Builder.Default
+	private List<Memo> memos = new ArrayList<>();
 
 	@OneToOne(mappedBy = "note", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Summary summary;
@@ -67,5 +68,39 @@ public class Note {
 	public void update(String title, String folder) {
 		if (title != null) this.title = title;
 		if (folder != null) this.folder = folder;
+	}
+
+	public void setBookmarks(List<Bookmark> bookmarks) {
+		this.bookmarks.clear();
+		if (bookmarks != null) {
+			bookmarks.forEach(this::addBookmark);
+		}
+	}
+
+	public void setMemos(List<Memo> memos) {
+		this.memos.clear();
+		if (memos != null) {
+			memos.forEach(this::addMemo);
+		}
+	}
+
+	public void addBookmark(Bookmark bookmark) {
+		this.bookmarks.add(bookmark);
+		bookmark.setNote(this);
+	}
+
+	public void removeBookmark(Bookmark bookmark) {
+		this.bookmarks.remove(bookmark);
+		bookmark.setNote(null);
+	}
+
+	public void addMemo(Memo memo) {
+		this.memos.add(memo);
+		memo.setNote(this);
+	}
+
+	public void removeMemo(Memo memo) {
+		this.memos.remove(memo);
+		memo.setNote(null);
 	}
 }

--- a/backend/src/main/java/bento/backend/dto/request/NoteCreateRequest.java
+++ b/backend/src/main/java/bento/backend/dto/request/NoteCreateRequest.java
@@ -1,14 +1,10 @@
 package bento.backend.dto.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-
 
 @Getter
 @Setter
@@ -23,7 +19,6 @@ public class NoteCreateRequest {
 	@NotBlank(message = "File is mandatory")
 	private MultipartFile file;
 
-	private List<BookmarkCreateRequest> bookmarks; // 북마크 리스트
-
-	private List<MemoCreateRequest> memos;     // 메모 리스트
+	private String bookmarks; // 북마크 리스트
+	private String memos;     // 메모 리스트
 }

--- a/backend/src/main/java/bento/backend/dto/request/NoteCreateRequest.java
+++ b/backend/src/main/java/bento/backend/dto/request/NoteCreateRequest.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 
 @Getter
 @Setter
@@ -26,4 +28,8 @@ public class NoteCreateRequest {
 
 	@NotBlank(message = "File is mandatory")
 	private MultipartFile file;
+
+	private List<BookmarkCreateRequest> bookmarks; // 북마크 리스트
+
+	private List<MemoCreateRequest> memos;     // 메모 리스트
 }

--- a/backend/src/main/java/bento/backend/service/note/NoteService.java
+++ b/backend/src/main/java/bento/backend/service/note/NoteService.java
@@ -92,15 +92,19 @@ public class NoteService {
 		List<BookmarkCreateRequest> bookmarkRequests;
 		List<MemoCreateRequest> memoRequests;
 
+		// Default empty JSON arrays if not provided
+		String bookmarkJson = (request.getBookmarks() == null) ? "[]" : request.getBookmarks();
+		String memoJson = (request.getMemos() == null) ? "[]" : request.getMemos();
+
 		try {
 			// Parse bookmarks and memos
 			bookmarkRequests = objectMapper.readValue(
-					request.getBookmarks(),
+					bookmarkJson,
                     new TypeReference<>() {
                     }
 			);
 			memoRequests = objectMapper.readValue(
-					request.getMemos(),
+					memoJson,
                     new TypeReference<>() {
                     }
 			);
@@ -130,7 +134,6 @@ public class NoteService {
 		}
 
 		noteRepository.save(note);
-
 		return MessageResponse.builder()
 				.message("Note created successfully")
 				.build();


### PR DESCRIPTION
## 🔍 What is this PR?
<!-- 관련있는 Issue 번호(#000)을 적어주세요 ex) "#1234" -->
<!-- 추가 설명을 적어주세요 -->
- 실시간 노트 생성 시, 요청에 bookmark 와 memo를 포함하여 전송할 수 있도록 api를 수정했습니다.

## 📝 Changes
<!-- 수정된 내용을 적어주세요 -->
```text
### 노트 추가 ###########################################################
POST {{host}}/notes
Authorization: Bearer {{authToken}}
Content-Type: multipart/form-data; boundary=boundary

--boundary
Content-Disposition: form-data; name="title"

test title

--boundary
Content-Disposition: form-data; name="folder"

deep-learning

--boundary
Content-Disposition: form-data; name="file"; filename="presentation.txt"
Content-Type: text/plain

< /Users/leesiha/Downloads/presentation.txt
--boundary--
Content-Disposition: form-data; name="bookmarks"
Content-Type: application/json

[]
--boundary
Content-Disposition: form-data; name="memos"
Content-Type: application/json

[]
--boundary--
``` 
- name="bookmarks"와 name="memos" 에 있는 [] 안에 각각 북마크와 메모 정보를 추가하고, 
- json 형태로 전송 시 한 번에 save 가능합니다. 예시는 아래 사진과 같습니다.
<img width="629" alt="스크린샷 2024-11-27 오후 11 21 32" src="https://github.com/user-attachments/assets/a0fbc666-4df8-4d9b-9289-a2f9f45e7406">


## ✔️ CheckList
<!-- 확인해야 할 사항을 적어주세요 -->
- [ ] []를 작성하지 않아도 작동시키는 방법 찾기
(exception handlng 하면 처리 될 것 같은데... 지금은 방법이 안 보입니다)
