### PR TITLE
:sparkles:: 노트 엔티티에 토픽 추가

### DIFF
--- a/backend/src/main/java/bento/backend/domain/Note.java
+++ b/backend/src/main/java/bento/backend/domain/Note.java
@@ -1,5 +1,6 @@
 package bento.backend.domain;
 
+import bento.backend.dto.converter.GenericJsonConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -26,6 +27,11 @@ public class Note {
 
 	@Column(name = "title")
 	private String title;
+
+	@Column(name = "topic", columnDefinition = "json")
+	@Convert(converter = GenericJsonConverter.class)
+	@Builder.Default
+	private List<String> topics = new ArrayList<>();
 
 	@Column(name = "content", columnDefinition = "json")
 	private String content;

--- a/backend/src/main/java/bento/backend/dto/converter/GenericJsonConverter.java
+++ b/backend/src/main/java/bento/backend/dto/converter/GenericJsonConverter.java
@@ -1,0 +1,39 @@
+package bento.backend.dto.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class GenericJsonConverter implements AttributeConverter<List<String>, String> {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting List<String> to JSON", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return new ArrayList<>();
+        }
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting JSON to List<String>", e);
+        }
+    }
+}

--- a/backend/src/main/java/bento/backend/dto/request/NoteCreateRequest.java
+++ b/backend/src/main/java/bento/backend/dto/request/NoteCreateRequest.java
@@ -21,4 +21,5 @@ public class NoteCreateRequest {
 
 	private String bookmarks; // 북마크 리스트
 	private String memos;     // 메모 리스트
+	private String topics; 	  // 주제 리스트
 }

--- a/backend/src/main/java/bento/backend/service/note/NoteService.java
+++ b/backend/src/main/java/bento/backend/service/note/NoteService.java
@@ -82,7 +82,7 @@ public class NoteService {
 
         Note note = Note.builder()
                 .title(request.getTitle())
-                .content(jsonContent.toString())
+                .content(jsonContent.toString()) // TODO: 실제 콘텐츠 설정
                 .folder(folder)
                 .audio(audio)
                 .user(user)
@@ -90,28 +90,25 @@ public class NoteService {
 
         // Add bookmarks and memos if present
         ObjectMapper objectMapper = new ObjectMapper();
+        List<String> topics;
         List<BookmarkCreateRequest> bookmarkRequests;
         List<MemoCreateRequest> memoRequests;
 
         // Default empty JSON arrays if not provided
+        String topicsJson = (request.getTopics() == null) ? "[]" : request.getTopics();
         String bookmarkJson = (request.getBookmarks() == null) ? "[]" : request.getBookmarks();
         String memoJson = (request.getMemos() == null) ? "[]" : request.getMemos();
 
         try {
-            // Parse bookmarks and memos
-            bookmarkRequests = objectMapper.readValue(
-                    bookmarkJson,
-                    new TypeReference<>() {
-                    }
-            );
-            memoRequests = objectMapper.readValue(
-                    memoJson,
-                    new TypeReference<>() {
-                    }
-            );
+            // Parse topics, bookmarks, and memos
+            topics = objectMapper.readValue( topicsJson, new TypeReference<>() {} );
+            bookmarkRequests = objectMapper.readValue( bookmarkJson, new TypeReference<>() {} );
+            memoRequests = objectMapper.readValue( memoJson, new TypeReference<>() {} );
         } catch (JsonProcessingException e) {
             throw new ValidationException(ErrorMessages.INVALID_JSON_FORMAT);
         }
+        note.getTopics().addAll(topics);
+
         List<Bookmark> bookmarks = bookmarkRequests.stream()
                 .map(bookmarkRequest -> Bookmark.builder()
                         .timestamp(bookmarkRequest.getTimestamp())


### PR DESCRIPTION
## 🔍 What is this PR?
<!-- 관련있는 Issue 번호(#000)을 적어주세요 ex) "#1234" -->
<!-- 추가 설명을 적어주세요 -->
- #22 
### GenericJsonConverter
- JPA 엔티티의 List<String> 필드를 데이터베이스의 JSON 문자열로 매핑하고, 
반대로 데이터베이스에 저장된 JSON 문자열을 다시 List<String>으로 변환해주는 JPA Attribute Converter입니다. 
#### 주요 기능
1. 데이터 변환:
    - **엔티티 → 데이터베이스**: `List<String>` 데이터를 JSON 문자열로 변환하여 데이터베이스에 저장.
    - **데이터베이스 → 엔티티**: JSON 문자열을 `List<String>`로 변환하여 엔티티에 매핑.
2. JPA에서 사용 가능:
    - JPA 필드에 쉽게 적용할 수 있습니다(`@Converter`를 사용하여 선언).

### 왜 Bookmark, Memo에는 적용하지 않았나?
#### GenericJsonConverter를 사용할 수 없는 경우
- Bookmark와 Memo는 데이터베이스에서 특정 조건으로 검색해야 할 가능성이 큽니다. JSON으로 저장하면 SQL 쿼리에서 효율적으로 검색할 수 없습니다.
- Bookmark와 Memo는 단순한 리스트 형태가 아니라, 각각 독립적인 속성(예: 타임스탬프, 메모 내용 등)을 가진 테이블이 존재하므로, JSON 변환은 적합하지 않습니다.
> Bookmark와 Memo는 데이터베이스 테이블로써 독립적으로 관리해야 하며, JPA의 관계 매핑(`@OneToMany`, `@ManyToOne`)을 사용하는 것이 더 적합합니다. 
반면, topics처럼 단순한 List<String> 데이터는 JSON 문자열로 변환하여 데이터베이스에 저장하는 방식이 효율적입니다.

## ✔️ CheckList
<!-- 확인해야 할 사항을 적어주세요 -->
- [ ] 토픽 수정 기능은 없습니다만, 추가하는 것이 좋을까요? 
(수정한다고 해서 STT 결과가 달라지지 않기 때문에, 수정 불가능으로 설정하는 것이 좋다고 생각합니다.)
