### PR TITLE
Feature/33 note search

### DIFF
--- a/backend/src/main/java/bento/backend/BackendApplication.java
+++ b/backend/src/main/java/bento/backend/BackendApplication.java
@@ -2,10 +2,12 @@ package bento.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/bento/backend/constant/ErrorMessages.java
+++ b/backend/src/main/java/bento/backend/constant/ErrorMessages.java
@@ -4,6 +4,7 @@ public class ErrorMessages {
     public static final String USER_ID_NOT_FOUND_ERROR = "User with the specified ID could not be found : ";
     public static final String USER_EMAIL_NOT_FOUND_ERROR = "No user found associated with the provided email address : ";
     public static final String USER_EMAIL_EMPTY_ERROR = "Email address cannot be empty.";
+    public static final String USER_NOT_ACTIVE_ERROR = "The user account is not active. Please contact support for assistance.";
     public static final String DUPLICATE_USERNAME_ERROR = "Username is already taken. Please choose a different username.";
     public static final String DUPLICATE_EMAIL_ERROR = "An account with the provided email address already exists. Please use a different email address.";
     public static final String SAME_EMAIL_ERROR = "The new email address is the same as the current email address. Please provide a different email address.";
@@ -22,6 +23,8 @@ public class ErrorMessages {
     public static final String MEMO_ALREADY_EXISTS_ERROR = "A memo with the same timestamp already exists for this note.";
     public static final String MEMO_ID_NOT_FOUND_ERROR = "The memo with the specified ID could not be found : ";
     public static final String INVALID_JSON_FORMAT = "The provided JSON data is invalid. Please check bookmarks and memos and try again.";
-    public static final String USER_NOT_ACTIVE_ERROR = "The user account is not active. Please contact support for assistance.";
+    public static final String INVALID_DATE_FORMAT = "The provided date format is invalid. Please provide a valid date in the format yyyy-MM-dd.";
+    public static final String EMPTY_QUERY = "The search query cannot be empty if you want to search notes. Are you looking for date range search?";
+    public static final String EMPTY_CONTENT = "The note content cannot be empty. Please provide some content for the note.";
     // 필요한 다른 에러 메시지들을 추가
 }

--- a/backend/src/main/java/bento/backend/controller/NoteController.java
+++ b/backend/src/main/java/bento/backend/controller/NoteController.java
@@ -1,14 +1,10 @@
 package bento.backend.controller;
 
+import bento.backend.dto.response.*;
 import bento.backend.service.note.NoteService;
 import bento.backend.service.file.FileService;
 import bento.backend.domain.User;
 import bento.backend.domain.Folder;
-import bento.backend.dto.response.NoteListResponse;
-import bento.backend.dto.response.NoteDetailResponse;
-import bento.backend.dto.response.MessageResponse;
-import bento.backend.dto.response.FolderResponse;
-import bento.backend.dto.response.NoteSummaryResponse;
 import bento.backend.dto.request.NoteCreateRequest;
 import bento.backend.dto.request.NoteUpdateRequest;
 
@@ -52,6 +48,19 @@ public class NoteController {
 	public ResponseEntity<List<NoteListResponse>> getNote(@AuthenticationPrincipal Long userId) {
 		User user = userService.getUserById(userId);
 		return ResponseEntity.status(200).body(noteService.getNoteList(user));
+	}
+
+	// 노트 검색
+	@GetMapping("/search")
+	public ResponseEntity<List<NoteSearchResponse>> searchNotes(
+			@AuthenticationPrincipal Long userId,
+			@RequestParam(required = false) String query,
+			@RequestParam(required = false) String startDate,
+			@RequestParam(required = false) String endDate
+	) {
+		User user = userService.getUserById(userId);
+		List<NoteSearchResponse> results = noteService.searchNotes(user, query, startDate, endDate);
+		return ResponseEntity.status(200).body(results);
 	}
 
 	// 노트 목록 조회 (폴더별)

--- a/backend/src/main/java/bento/backend/dto/converter/GenericJsonConverter.java
+++ b/backend/src/main/java/bento/backend/dto/converter/GenericJsonConverter.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Converter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Converter
 public class GenericJsonConverter implements AttributeConverter<List<String>, String> {
@@ -34,6 +35,23 @@ public class GenericJsonConverter implements AttributeConverter<List<String>, St
             return objectMapper.readValue(dbData, new TypeReference<>() {});
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error converting JSON to List<String>", e);
+        }
+    }
+
+    /**
+     * JSON String 을 Map<String, Object> 로 변환합니다.
+     *
+     * @param json The JSON String.
+     * @return Parsed Map<String, Object>.
+     */
+    public Map<String, Object> convertJsonToMap(String json) {
+        if (json == null || json.isEmpty()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting JSON to Map<String, Object>", e);
         }
     }
 }

--- a/backend/src/main/java/bento/backend/dto/response/NoteContentMatch.java
+++ b/backend/src/main/java/bento/backend/dto/response/NoteContentMatch.java
@@ -1,0 +1,14 @@
+package bento.backend.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NoteContentMatch {
+    private String text;
+    private String timestamp;
+}
+

--- a/backend/src/main/java/bento/backend/dto/response/NoteSearchResponse.java
+++ b/backend/src/main/java/bento/backend/dto/response/NoteSearchResponse.java
@@ -1,0 +1,20 @@
+package bento.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class NoteSearchResponse {
+    private Long noteId;          // 노트 ID
+    private String title;         // 노트 제목
+    private String folder;        // 폴더 이름
+    private String createdAt;     // 생성일
+    private List<NoteContentMatch> matches; // 검색어가 포함된 문장 리스트
+}

--- a/backend/src/main/java/bento/backend/repository/NoteRepository.java
+++ b/backend/src/main/java/bento/backend/repository/NoteRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.List;
 
@@ -17,4 +18,15 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 	List<Note> findAllByUserAndFolder(User user, Folder folder);
 	@Query("SELECT n.user.userId FROM Note n WHERE n.noteId = :noteId")
 	Optional<Long> findUserIdByNoteId(@Param("noteId") Long noteId);
+
+	@Query("SELECT n FROM Note n WHERE n.user = :user AND n.createdAt BETWEEN :startDate AND :endDate")
+	List<Note> findByCreatedAtBetweenAndUser(
+			@Param("startDate") LocalDateTime startDate,
+			@Param("endDate") LocalDateTime endDate,
+			@Param("user") User user);
+
+	@Query("SELECT n FROM Note n WHERE n.user = :user AND (LOWER(n.title) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(n.content) LIKE LOWER(CONCAT('%', :query, '%')))")
+	List<Note> findByQueryAndUser(
+			@Param("query") String query,
+			@Param("user") User user);
 }

--- a/documents/openapi.yaml
+++ b/documents/openapi.yaml
@@ -810,16 +810,6 @@ paths:
                   message:
                     type: string
                     example: "The provided token is invalid. Please check and provide a valid token."
-        404:
-          description: No notes found matching the criteria.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    example: "No notes found for the specified criteria."
   /notes/{noteId}:
     get:
       tags:

--- a/documents/openapi.yaml
+++ b/documents/openapi.yaml
@@ -722,6 +722,104 @@ paths:
                 example:
                   title: "Title is mandatory"
                   folder: "Folder is mandatory"
+  /notes/search:
+    get:
+      tags:
+        - Notes
+      summary: Search notes
+      description: Searches notes in the system based on the provided query, date range, or other criteria.
+      operationId: searchNotes
+      parameters:
+        - name: query
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Text to search for within the notes' content or title.
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+            example: "2024-12-01"
+          description: Start date of the search range in `yyyy-MM-dd` format.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+            example: "2024-12-03"
+          description: End date of the search range in `yyyy-MM-dd` format.
+      responses:
+        200:
+          description: A list of notes matching the search criteria.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    noteId:
+                      type: integer
+                      example: 1
+                    title:
+                      type: string
+                      example: "My first note"
+                    folder:
+                      type: string
+                      example: "deep learning"
+                    createdAt:
+                      type: string
+                      format: date-time
+                      example: "2024-12-03 03:19:32"
+                    duration:
+                      type: string
+                      example: "01:00:00"
+                    matches:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          text:
+                            type: string
+                            example: "Example matching text"
+                          timestamp:
+                            type: string
+                            format: time
+                            example: "00:00:41"
+        400:
+          description: Bad Request - Invalid parameters or date formats.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "The provided date format is invalid. Please provide a valid date in the format yyyy-MM-dd."
+        401:
+          description: Unauthorized - Invalid authentication token.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "The provided token is invalid. Please check and provide a valid token."
+        404:
+          description: No notes found matching the criteria.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "No notes found for the specified criteria."
   /notes/{noteId}:
     get:
       tags:


### PR DESCRIPTION
## 🔍 What is this PR?
<!-- 관련있는 Issue 번호(#000)을 적어주세요 ex) "#1234" -->
- Resolves #33 

<!-- 추가 설명을 적어주세요 -->
- 노트 검색 API 구현 완료.
- 사용자가 특정 검색어(`query`)로 노트 내용을 검색하거나, 날짜 범위(`startDate`, `endDate`) 내에서 작성된 노트를 조회할 수 있는 기능을 추가했습니다.

---

## 📝 Changes
<!-- 수정된 내용을 적어주세요 -->
1. **노트 검색 기능 구현**
   - `query`: 노트의 `content` 필드에서 특정 텍스트를 검색.
   - `startDate`, `endDate`: 날짜 범위 내 작성된 노트들을 반환.
   - `matches`: 검색 결과와 관련된 매칭된 텍스트(`text`) 및 타임스탬프(`timestamp`) 정보를 포함.
   
2. **검색 결과의 JSON 응답**
   - 응답 구조:
     ```json
     [
       {
         "noteId": 1,
         "title": "note-1",
         "folder": "folder-1",
         "createdAt": "2024-12-03 03:19:32",
         "matches": [
           {
             "text": "검색어와 매칭된 텍스트",
             "timestamp": "00:00:41"
           }
         ]
       }
     ]
     ```

3. **유효성 검증**
   - 잘못된 날짜 형식(`yyyy-MM-dd` 형식 위반) 입력 시 `400 Bad Request` 반환.
   - `query`가 없거나 비어 있을 경우 예외 처리.

4. **Swagger 명세 업데이트**
   - `GET /notes/search` API 명세 추가.
   - 요청 파라미터:
     - `query` (optional)
     - `startDate` (optional)
     - `endDate` (optional)
   - 성공 및 에러 응답 명세 정의.

---

## ✔️ CheckList
<!-- 확인해야 할 사항을 적어주세요 -->
- [x] 날짜 범위 검색 및 쿼리 매칭 동작 확인.
- [x] 유효성 검증(400, 401 에러 시나리오) 테스트 완료.
- [x] Swagger 명세와 구현된 API의 일관성 확인.
